### PR TITLE
Update slackbot

### DIFF
--- a/slackbot/cloudbuild.yaml
+++ b/slackbot/cloudbuild.yaml
@@ -1,6 +1,13 @@
 steps:
 - name: 'gcr.io/cloud-builders/docker'
-  args: [ 'build', '-t', 'gcr.io/$PROJECT_ID/slackbot', '.' ]
-images:
-- 'gcr.io/$PROJECT_ID/slackbot'
-tags: ['cloud-builders-community']
+  entrypoint: "/bin/bash"
+  args: 
+    - -c
+    - 'docker build 
+          -t gcr.io/$PROJECT_ID/slackbot:v0.2 .'
+- name: 'gcr.io/cloud-builders/docker'
+  entrypoint: "/bin/bash"
+  args: 
+    - -c
+    - |
+      docker push gcr.io/$PROJECT_ID/slackbot:v0.2

--- a/slackbot/main.go
+++ b/slackbot/main.go
@@ -12,12 +12,20 @@ import (
 
 var (
 	buildId     = flag.String("build", "", "Id of monitored Build")
-	webhook     = flag.String("webhook", "", "Slack webhook URL")
 	project     = flag.String("project", "unknown", "Project name being built")
+	auth        = flag.String("auth", "webhook", "Authentication method to Slack, can be webhook or token")
 	mode        = flag.String("mode", "trigger", "Mode the builder runs in")
 	copyName    = flag.Bool("copy-name", false, "Copy name of slackbot's build step from monitored build to watcher build")
 	copyTags    = flag.Bool("copy-tags", false, "Copy tags from monitored build to watcher build")
 	copyTimeout = flag.Bool("copy-timeout", false, "Copy timeout from monitored build to watcher build")
+
+	// token authentication
+	channel = flag.String("channel", "", "Name of the channel to send message to")
+	env     = flag.String("env", "dev", "Indication of environment, to denote the level of alert to produce")
+	token   = flag.String("token", "", "Token to authenticate slackbot")
+
+	// webhook authentication
+	webhook = flag.String("webhook", "", "Slack webhook URL")
 )
 
 func main() {
@@ -25,16 +33,20 @@ func main() {
 	flag.Parse()
 	ctx := context.Background()
 
-	if *webhook == "" {
+	if *auth != "webhook" && *auth != "token" {
+		log.Fatalf("Invalid auth method selected, must be one of: webhook, token")
+	}
+
+	if *auth == "webhook" && *webhook == "" {
 		log.Fatalf("Slack webhook must be provided.")
+	}
+
+	if *auth == "token" && (*channel == "" || *token == "") {
+		log.Fatalf("Channel and bot token must be provided for token-based authorization.")
 	}
 
 	if *buildId == "" {
 		log.Fatalf("Build ID must be provided.")
-	}
-
-	if *mode == "" {
-		log.Fatalf("Mode must be provided.")
 	}
 
 	if *mode != "trigger" && *mode != "monitor" {
@@ -49,14 +61,14 @@ func main() {
 	if *mode == "trigger" {
 		// Trigger another build to run the monitor.
 		log.Printf("Starting trigger mode for build %s", *buildId)
-		slackbot.Trigger(ctx, projectId, *buildId, *webhook, *project, *copyName, *copyTags, *copyTimeout)
+		slackbot.Trigger(ctx, projectId, *buildId, *webhook, *project, *auth, *channel, *env, *token, *copyName, *copyTags, *copyTimeout)
 		return
 	}
 
 	if *mode == "monitor" {
 		// Monitor the other build until completion.
 		log.Printf("Starting monitor mode for build %s", *buildId)
-		slackbot.Monitor(ctx, projectId, *buildId, *webhook, *project)
+		slackbot.Monitor(ctx, projectId, *buildId, *webhook, *project, *auth, *channel, *env, *token)
 		return
 	}
 }

--- a/slackbot/slackbot/convention.go
+++ b/slackbot/slackbot/convention.go
@@ -1,0 +1,40 @@
+package slackbot
+
+import (
+	cloudbuild "google.golang.org/api/cloudbuild/v1"
+)
+
+type SlackCreateMessageResponse struct {
+	Ok      bool   `json:"ok"`
+	Channel string `json:"channel"`
+	Ts      string `json:"ts"`
+}
+
+type AlertLevel int32
+
+const (
+	AlertLevel_INFO AlertLevel = 0
+	AlertLevel_ERR  AlertLevel = 1
+)
+
+type Notifier interface {
+	Notify(build *cloudbuild.Build)
+	NotifyStep(build *cloudbuild.Build)
+}
+
+type WebhookNotifier struct {
+	webhook    string
+	project    string
+	projectId  string
+	alertLevel AlertLevel
+}
+
+type TokenNotifier struct {
+	project          string
+	projectId        string
+	channel          string
+	token            string
+	alertLevel       AlertLevel
+	threadTs         string
+	lastStepNotified int
+}

--- a/slackbot/slackbot/monitor.go
+++ b/slackbot/slackbot/monitor.go
@@ -13,11 +13,22 @@ const tickDuration = 20 * time.Second
 const monitorErrorMarginDuration = (maxErrors + 1) * tickDuration
 
 // Monitor polls Cloud Build until the build reaches completed status, then triggers the Slack event.
-func Monitor(ctx context.Context, projectId string, buildId string, webhook string, project string) {
+func Monitor(ctx context.Context, projectId string, buildId string, webhook string, project string, auth string, channel string, env string, token string) {
 	svc := gcbClient(ctx)
 	errors := 0
 	started := false
-
+	var notifier Notifier
+	var alertLevel AlertLevel
+	if env == "dev" {
+		alertLevel = AlertLevel_INFO
+	} else {
+		alertLevel = AlertLevel_ERR
+	}
+	if auth == "token" {
+		notifier = NewTokenNotifier(project, projectId, channel, token, alertLevel)
+	} else if auth == "webhook" {
+		notifier = NewWebhookNotifier(webhook, project, projectId, alertLevel)
+	}
 	t := time.Tick(tickDuration)
 	for {
 		log.Printf("Polling build %s", buildId)
@@ -36,12 +47,15 @@ func Monitor(ctx context.Context, projectId string, buildId string, webhook stri
 		case "WORKING":
 			if !started {
 				log.Printf("Build started. Notifying")
-				Notify(monitoredBuild, webhook, project, projectId)
+				notifier.Notify(monitoredBuild)
 				started = true
+			} else {
+				notifier.NotifyStep(monitoredBuild)
 			}
 		case "SUCCESS", "FAILURE", "INTERNAL_ERROR", "TIMEOUT", "CANCELLED":
 			log.Printf("Terminal status reached. Notifying")
-			Notify(monitoredBuild, webhook, project, projectId)
+			notifier.NotifyStep(monitoredBuild)
+			notifier.Notify(monitoredBuild)
 			return
 		}
 		<-t

--- a/slackbot/slackbot/notify.go
+++ b/slackbot/slackbot/notify.go
@@ -1,6 +1,7 @@
 package slackbot
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -11,34 +12,43 @@ import (
 	cloudbuild "google.golang.org/api/cloudbuild/v1"
 )
 
-// Notify posts a notification to Slack that the build is complete.
-func Notify(b *cloudbuild.Build, webhook string, project string, projectId string) {
-	url := fmt.Sprintf("https://console.cloud.google.com/cloud-build/builds/%s?project=%s", b.Id, projectId)
-	var i string
-	switch b.Status {
+func NewWebhookNotifier(webhook string, project string, projectId string, alertLevel AlertLevel) *WebhookNotifier {
+	return &WebhookNotifier{
+		webhook, project, projectId, alertLevel,
+	}
+}
+
+func (n *WebhookNotifier) Notify(build *cloudbuild.Build) {
+	url := fmt.Sprintf("https://console.cloud.google.com/cloud-build/builds/%s?project=%s", build.Id, n.projectId)
+	var emoji string
+	switch build.Status {
 	case "WORKING":
-		i = ":hammer:"
+		emoji = ":hammer:"
 	case "SUCCESS":
-		i = ":white_check_mark:"
+		emoji = ":white_check_mark:"
 	case "FAILURE":
-		i = ":x:"
+		emoji = ":x:"
 	case "CANCELLED":
-		i = ":wastebasket:"
+		emoji = ":wastebasket:"
 	case "TIMEOUT":
-		i = ":hourglass:"
+		emoji = ":hourglass:"
 	case "STATUS_UNKNOWN", "INTERNAL_ERROR":
-		i = ":interrobang:"
+		emoji = ":interrobang:"
 	default:
-		i = ":question:"
+		emoji = ":question:"
+	}
+	tagAlert := ""
+	if n.alertLevel == AlertLevel_ERR && (build.Status == "TIMEOUT" || build.Status == "FAILURE" || build.Status == "INTERNAL_ERROR") {
+		tagAlert = "<!subteam^S014F8S6EBH> "
 	}
 
 	// Ensure messages remain the same as before
-	if project == "unknown" {
-		project = ""
+	if n.project == "unknown" {
+		n.project = ""
 	}
 
 	var msg string
-	if b.Status == "WORKING" {
+	if build.Status == "WORKING" {
 		msgFmt := `{
 			"text": "%s *%s* build started",
 			"attachments": [{
@@ -50,20 +60,20 @@ func Notify(b *cloudbuild.Build, webhook string, project string, projectId strin
 				}]
 			}]
 		}`
-		msg = fmt.Sprintf(msgFmt, i, project, url, url)
+		msg = fmt.Sprintf(msgFmt, emoji, n.project, url, url)
 	} else {
-		startTime, err := time.Parse(time.RFC3339, b.StartTime)
+		startTime, err := time.Parse(time.RFC3339, build.StartTime)
 		if err != nil {
 			log.Fatalf("Failed to parse Build.StartTime: %v", err)
 		}
-		finishTime, err := time.Parse(time.RFC3339, b.FinishTime)
+		finishTime, err := time.Parse(time.RFC3339, build.FinishTime)
 		if err != nil {
 			log.Fatalf("Failed to parse Build.FinishTime: %v", err)
 		}
 		buildDuration := finishTime.Sub(startTime).Truncate(time.Second)
 
 		msgFmt := `{
-			"text": "%s *%s* build _%s_ after _%s_",
+			"text": "%s *%s* build _%s_ after _%s_ %s",
 			"attachments": [{
 				"fallback": "Open build details at %s",
 				"actions": [{
@@ -73,15 +83,181 @@ func Notify(b *cloudbuild.Build, webhook string, project string, projectId strin
 				}]
 			}]
 		}`
-		msg = fmt.Sprintf(msgFmt, i, project, b.Status, buildDuration, url, url)
+		msg = fmt.Sprintf(msgFmt, emoji, n.project, build.Status, buildDuration, tagAlert, url, url)
 	}
 
 	r := strings.NewReader(msg)
-	resp, err := http.Post(webhook, "application/json", r)
+	resp, err := http.Post(n.webhook, "application/json", r)
 	if err != nil {
 		log.Fatalf("Failed to post to Slack: %v", err)
 	}
 	defer resp.Body.Close()
 	body, _ := ioutil.ReadAll(resp.Body)
 	log.Printf("Posted message to Slack: [%v], got response [%s]", msg, body)
+}
+
+func (n *WebhookNotifier) NotifyStep(build *cloudbuild.Build) {
+
+}
+
+func NewTokenNotifier(project string, projectId string, channel string, token string, alertLevel AlertLevel) *TokenNotifier {
+	return &TokenNotifier{
+		project, projectId, channel, token, alertLevel, "", -1,
+	}
+}
+
+func (n *TokenNotifier) Notify(build *cloudbuild.Build) {
+	url := fmt.Sprintf("https://console.cloud.google.com/cloud-build/builds/%s?project=%s", build.Id, n.projectId)
+	var emoji string
+
+	switch build.Status {
+	case "WORKING":
+		emoji = ":hammer:"
+	case "SUCCESS":
+		emoji = ":white_check_mark:"
+	case "FAILURE":
+		emoji = ":x:"
+	case "CANCELLED":
+		emoji = ":wastebasket:"
+	case "TIMEOUT":
+		emoji = ":hourglass:"
+	case "STATUS_UNKNOWN", "INTERNAL_ERROR":
+		emoji = ":interrobang:"
+	default:
+		emoji = ":question:"
+	}
+
+	tagAlert := ""
+	if n.alertLevel == AlertLevel_ERR && (build.Status == "TIMEOUT" || build.Status == "FAILURE" || build.Status == "INTERNAL_ERROR") {
+		tagAlert = "<!subteam^S014F8S6EBH> "
+	}
+	// Ensure messages remain the same as before
+	if n.project == "unknown" {
+		n.project = ""
+	}
+
+	var msg string
+	if build.Status == "WORKING" {
+		msgFmt := `{
+			"text": "%s *%s* build started",
+			"attachments": [{
+				"fallback": "Open build details at %s",
+				"actions": [{
+					"type": "button",
+					"text": "Open details",
+					"url": "%s"
+				}]
+			}],
+			"channel": "%s"
+		}`
+		msg = fmt.Sprintf(msgFmt, emoji, n.project, url, url, n.channel)
+	} else {
+		startTime, err := time.Parse(time.RFC3339, build.StartTime)
+		if err != nil {
+			log.Fatalf("Failed to parse Build.StartTime: %v", err)
+		}
+		finishTime, err := time.Parse(time.RFC3339, build.FinishTime)
+		if err != nil {
+			log.Fatalf("Failed to parse Build.FinishTime: %v", err)
+		}
+		buildDuration := finishTime.Sub(startTime).Truncate(time.Second)
+
+		var msgFmt string
+		msgFmt = `{
+			"text": "%s *%s* build _%s_ after _%s_ %s",
+			"attachments": [{
+				"fallback": "Open build details at %s",
+				"actions": [{
+					"type": "button",
+					"text": "Open details",
+					"url": "%s"
+				}]
+			}],
+			"channel": "%s",
+			"thread_ts": "%s"
+		}`
+		msg = fmt.Sprintf(msgFmt, emoji, n.project, build.Status, buildDuration, tagAlert, url, url, n.channel, n.threadTs)
+	}
+
+	client := &http.Client{}
+	r, err := http.NewRequest(http.MethodPost, "https://slack.com/api/chat.postMessage", strings.NewReader(msg))
+	if err != nil {
+		log.Fatalf("Unable to construct http call, %s", err.Error())
+	}
+	r.Header.Add("Authorization", "Bearer "+n.token)
+	r.Header.Add("Content-Type", "application/json")
+
+	response, err := client.Do(r)
+	if err != nil {
+		log.Fatalf("Unable to send Slack message, %s", err.Error())
+	}
+
+	defer response.Body.Close()
+	var responseBody SlackCreateMessageResponse
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		log.Fatalf("Unable to decode Slack response, %s", err.Error())
+	}
+	err = json.Unmarshal(body, &responseBody)
+	if err != nil {
+		log.Fatalf("Unable to unmarshal JSON Slack response, %s", err.Error())
+	}
+	log.Printf("Posted message to Slack: [%v], got response [%s], with thread ts [%s]", msg, responseBody.Ok, responseBody.Ts)
+
+	if n.threadTs == "" {
+		n.threadTs = responseBody.Ts
+	}
+}
+
+func (n *TokenNotifier) NotifyStep(build *cloudbuild.Build) {
+	for i, step := range build.Steps {
+		var emoji string
+		log.Printf("Status %s, with last step %d", step.Status, n.lastStepNotified)
+		switch step.Status {
+		case "SUCCESS":
+			emoji = ":check_green:"
+		case "FAILURE", "INTERNAL_ERROR", "TIMEOUT", "EXPIRED":
+			emoji = ":x:"
+		case "STATUS_UNKNOWN", "CANCELLED":
+			emoji = ":notsureif:"
+		case "QUEUED", "WORKING", "":
+			return
+		}
+
+		msgFmt := `{
+			"text": "%s *Step %d*: %s",
+			"thread_ts": "%s",
+			"channel": "%s"
+		}`
+		msg := fmt.Sprintf(msgFmt, emoji, i, step.Id, n.threadTs, n.channel)
+
+		client := &http.Client{}
+		r, err := http.NewRequest(http.MethodPost, "https://slack.com/api/chat.postMessage", strings.NewReader(msg))
+		if err != nil {
+			log.Fatalf("Unable to construct http call, %s", err.Error())
+		}
+		r.Header.Add("Authorization", "Bearer "+n.token)
+		r.Header.Add("Content-Type", "application/json")
+
+		response, err := client.Do(r)
+		if err != nil {
+			log.Fatalf("Unable to send Slack message, %s", err.Error())
+		}
+
+		defer response.Body.Close()
+		var responseBody SlackCreateMessageResponse
+		body, err := ioutil.ReadAll(response.Body)
+
+		if err != nil {
+			log.Fatalf("Unable to decode Slack response, %s", err.Error())
+		}
+		err = json.Unmarshal(body, &responseBody)
+		if err != nil {
+			log.Fatalf("Unable to unmarshal JSON Slack response, %s", err.Error())
+		}
+		log.Printf("Posted message to Slack: [%v], got response [%s], with thread ts [%s]", msg, responseBody.Ok, responseBody.Ts)
+
+		n.lastStepNotified = i
+	}
+
 }

--- a/slackbot/slackbot/trigger.go
+++ b/slackbot/slackbot/trigger.go
@@ -4,23 +4,27 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"time"
 	"strings"
+	"time"
 
 	cloudbuild "google.golang.org/api/cloudbuild/v1"
 )
 
 // Trigger starts an independent watcher build.
-func Trigger(ctx context.Context, projectId string, buildId string, webhook string, project string, copyName bool, copyTags bool, copyTimeout bool) {
+func Trigger(ctx context.Context, projectId string, buildId string, webhook string, project string, auth string, channel string, env string, token string, copyName bool, copyTags bool, copyTimeout bool) {
 	svc := gcbClient(ctx)
 	watcherBuild := &cloudbuild.Build{
 		Steps: []*cloudbuild.BuildStep{
 			&cloudbuild.BuildStep{
-				Name: "gcr.io/$PROJECT_ID/slackbot",
+				Name: "gcr.io/$PROJECT_ID/slackbot:v0.2",
 				Args: []string{
 					fmt.Sprintf("--build=%s", buildId),
 					fmt.Sprintf("--webhook=%s", webhook),
 					fmt.Sprintf("--project=%s", project),
+					fmt.Sprintf("--auth=%s", auth),
+					fmt.Sprintf("--channel=%s", channel),
+					fmt.Sprintf("--env=%s", env),
+					fmt.Sprintf("--token=%s", token),
 					"--mode=monitor",
 				},
 			},

--- a/slackbot/testcloudbuild.yaml
+++ b/slackbot/testcloudbuild.yaml
@@ -1,0 +1,47 @@
+steps:
+  - name: gcr.io/google.com/cloudsdktool/cloud-sdk:323.0.0-alpine
+    id: Secret setup
+    entrypoint: "/bin/bash"
+    args:
+      - -c
+      - |
+        gcloud secrets versions access latest --secret=slack-finservbot | python3 -c "import sys, json; print(json.load(sys.stdin)['bot_user_oauth_access_token'])" > /workspace/bot_token
+        gcloud secrets versions access latest --secret=slack-finservbot | python3 -c "import sys, json; print(json.load(sys.stdin)['slack_webhook_token_finserv_alert_cicd'])" > /workspace/slack_url
+  - name: 'gcr.io/$PROJECT_ID/slackbot:v0.2'
+    id: Slackbot init
+    entrypoint: "/bin/sh"
+    args:
+      - -c
+      - |
+        TOKEN=$( cat /workspace/bot_token )
+        /app/main --build $BUILD_ID --project "Testing slackbot" --copy-timeout --channel "finserv-alert-common-stg" --token $$TOKEN --auth token --env dev
+        # /app/main --build $BUILD_ID --webhook "https://hooks.slack.com/services/$(cat /workspace/slack_url)" --project "Testing slackbot" --copy-timeout --auth webhook
+  - name: gcr.io/google.com/cloudsdktool/cloud-sdk:323.0.0-slim
+    id: First echo
+    entrypoint: "/bin/bash"
+    args:
+      - -c
+      - |
+        echo "This is step 1"
+  - name: gcr.io/google.com/cloudsdktool/cloud-sdk:323.0.0-alpine
+    entrypoint: "/bin/bash"
+    id: Second echo
+    args:
+      - -c
+      - |
+        echo "This is step 2"
+  - name: gcr.io/google.com/cloudsdktool/cloud-sdk:323.0.0-alpine
+    entrypoint: "/bin/bash"
+    id: Failing echo
+    args:
+      - -c
+      - |
+        echo "This is step 3 that will fail"
+        exit 1
+  - name: gcr.io/cloud-builders/docker
+    entrypoint: "/bin/bash"
+    id: Last echo
+    args:
+      - -c
+      - |
+        echo "This is step 4, but we'll never get here"


### PR DESCRIPTION
- Add versioned tag to both image and its usage as "sidecar" cloudbuild.
- Implement env separation via `env` flag (dev will not tag anyone, otherwise it will tag on Failed and Timeout builds)
- Implement token-based authentication to enable threading messages like below. Caveat, the steps status aren't real time, per [this](https://pkg.go.dev/google.golang.org/genproto/googleapis/devtools/cloudbuild/v1#BuildStep). It would have been nice if the steps can be real time, but this can still be helpful to combine all messages in 1 thread, including the last confirmation whether the build is successful or not. This subsequently introduces new parameters; `channel` and `token`.
![Screen Shot 2021-04-27 at 03 23 13](https://user-images.githubusercontent.com/6322125/116145853-062b2580-a708-11eb-8eb4-e614200a5e71.png)
- Implement interface in `Notify` function so that existing implementation is relatively isolated (existing implementation should be removed if we decide to go with this new format)
```go
if auth == "token" {
	notifier = NewTokenNotifier(project, projectId, channel, token, alertLevel)
} else if auth == "webhook" {
	notifier = NewWebhookNotifier(webhook, project, projectId, alertLevel)
}
```